### PR TITLE
update lock file

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -386,6 +386,11 @@ ipaddr.js@1.9.1:
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
   integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
 
+is-base64@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-base64/-/is-base64-1.1.0.tgz#8ce1d719895030a457c59a7dcaf39b66d99d56b4"
+  integrity sha512-Nlhg7Z2dVC4/PTvIFkgVVNvPHSO2eR/Yd0XzhGiXCXEvWnptXlXa/clQ8aePPiMuxEGcWfzWbGw2Fe3d+Y3v1g==
+
 is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
@@ -523,12 +528,13 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-pusher@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/pusher/-/pusher-3.0.0.tgz#710be1c534b0d834978d3abb2f27146b87adaf0c"
-  integrity sha512-r7oKdjs+BbUijyWE2MBUzsdLh7cG8HRJhHqLyPRTchV6JjLwKaRVHKAc0k4lGNuWflEqk2S31ph0VQnBoGDi8g==
+pusher@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/pusher/-/pusher-3.0.1.tgz#9fbed49cf0f9ee9879ae6b75a38f8dda7a98eded"
+  integrity sha512-jrI4N33paSh1vsYvEJx7QmXbf/zeeHIeoEAREqj4i2jJdK5I2FxhS96DsRl8+iwBJcsnk6TMMbfIrDniAFs5AA==
   dependencies:
     "@types/request" "^2.47.1"
+    is-base64 "^1.1.0"
     request "2.88.0"
     tweetnacl "^1.0.0"
     tweetnacl-util "^0.15.0"


### PR DESCRIPTION
Current our project doesn't deploy to heroku because our lockfile is out of date:

```
----> Node.js app detected
       
-----> Creating runtime environment
       
       NPM_CONFIG_LOGLEVEL=error
       NODE_ENV=production
       NODE_MODULES_CACHE=true
       NODE_VERBOSE=false
       
-----> Installing binaries
       engines.node (package.json):  ^11.15.0
       engines.npm (package.json):   unspecified (use default)
       engines.yarn (package.json):  unspecified (use default)
       
       Resolving node version ^11.15.0...
       Downloading and installing node 11.15.0...
       Using default npm version: 6.7.0
       Resolving yarn version 1.x...
       Downloading and installing yarn (1.22.4)...
       Installed yarn 1.22.4
       
-----> Installing dependencies
       Installing node modules (yarn.lock)
       yarn install v1.22.4
       [1/4] Resolving packages...
       error Your lockfile needs to be updated, but yarn was run with `--frozen-lockfile`.
       info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
-----> Build failed
 !     Outdated Yarn lockfile
       Your application contains a Yarn lockfile (yarn.lock) which does not
       match the dependencies in package.json. This can happen if you use npm
       to install or update a dependency instead of Yarn.
       Please run the following command in your application directory and check
       in the new yarn.lock file:
       $ yarn install
       $ git add yarn.lock
       $ git commit -m "Updated Yarn lockfile"
       $ git push heroku master
    
       https://help.heroku.com/TXYS53YJ
 !     Push rejected, failed to compile Node.js app.
 !     Push failed
```

I have run `yarn install` locally, and committed the updated yarn lock file.

